### PR TITLE
Add status-style index page for network services

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -1,10 +1,18 @@
-﻿@page
+@page
 @model IndexModel
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = "Service Status";
 }
 
-<div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+<div class="container py-4">
+    <h1 class="mb-4 text-center">Network Service Status</h1>
+    <div class="status-list">
+        @foreach (var service in Model.Services)
+        {
+            <div class="status-item">
+                <span>@service.Name</span>
+                <span class="status-text"><span class="status-indicator @(Model.StatusClass(service.Status))"></span>@service.Status</span>
+            </div>
+        }
+    </div>
 </div>

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,11 +1,14 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Collections.Generic;
 
 namespace VONet_Stats.Pages
 {
     public class IndexModel : PageModel
     {
         private readonly ILogger<IndexModel> _logger;
+
+        public IList<ServiceStatus> Services { get; private set; } = new List<ServiceStatus>();
 
         public IndexModel(ILogger<IndexModel> logger)
         {
@@ -14,7 +17,25 @@ namespace VONet_Stats.Pages
 
         public void OnGet()
         {
-
+            Services = new List<ServiceStatus>
+            {
+                new ServiceStatus { Name = "API Gateway", Status = "Operational" },
+                new ServiceStatus { Name = "Auth Service", Status = "Degraded" },
+                new ServiceStatus { Name = "Database", Status = "Down" }
+            };
         }
+
+        public string StatusClass(string status) => status switch
+        {
+            "Operational" => "status-up",
+            "Degraded" => "status-degraded",
+            _ => "status-down"
+        };
+    }
+
+    public class ServiceStatus
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
     }
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -20,3 +20,36 @@ html {
 body {
   margin-bottom: 60px;
 }
+
+.status-list {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.status-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.status-indicator {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+}
+
+.status-up {
+  background-color: #28a745;
+}
+
+.status-degraded {
+  background-color: #ffc107;
+}
+
+.status-down {
+  background-color: #dc3545;
+}


### PR DESCRIPTION
## Summary
- implement network service status list on index page
- provide sample service statuses and style classes
- add CSS for status indicators

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa307d2928832d81550e7f4829d270